### PR TITLE
Add project.yml for agentic team registration

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -1,0 +1,6 @@
+runtimes:
+  - node:22
+
+services: []
+
+mcp: []


### PR DESCRIPTION
Required by the agentic dev team `add-project` command.