### PR TITLE
feat: implement greeting mode functions (#2)

### DIFF
--- a/src/greetings.js
+++ b/src/greetings.js
@@ -1,0 +1,7 @@
+export function greet(name, mode) {
+  const resolvedMode = mode == null ? 'casual' : mode;
+  if (resolvedMode === 'casual') return `Hey ${name}!`;
+  if (resolvedMode === 'formal') return `Good day, ${name}. It is a pleasure.`;
+  if (resolvedMode === 'pirate') return `Ahoy, ${name}! Shiver me timbers!`;
+  throw new Error(`Unknown mode: ${mode}`);
+}

--- a/src/greetings.test.js
+++ b/src/greetings.test.js
@@ -1,0 +1,32 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { greet } from './greetings.js';
+
+describe('greet()', () => {
+  it('PAT-1: returns casual greeting', () => {
+    assert.equal(greet('Bob', 'casual'), 'Hey Bob!');
+  });
+
+  it('PAT-2: returns formal greeting', () => {
+    assert.equal(greet('Alice', 'formal'), 'Good day, Alice. It is a pleasure.');
+  });
+
+  it('PAT-3: returns pirate greeting', () => {
+    assert.equal(greet('Charlie', 'pirate'), 'Ahoy, Charlie! Shiver me timbers!');
+  });
+
+  it('PAT-4: defaults to casual when mode is undefined', () => {
+    assert.equal(greet('Dave'), 'Hey Dave!');
+  });
+
+  it('PAT-5: defaults to casual when mode is null', () => {
+    assert.equal(greet('Dave', null), 'Hey Dave!');
+  });
+
+  it('PAT-6: throws on unknown mode', () => {
+    assert.throws(
+      () => greet('Eve', 'unknown'),
+      { message: 'Unknown mode: unknown' }
+    );
+  });
+});


### PR DESCRIPTION
## Summary
Closes #2

Implements `src/greetings.js` exporting a `greet(name, mode)` function supporting formal, casual, and pirate modes. Defaults to casual when mode is undefined or null, and throws a descriptive error for unknown modes.

## Changes
- `src/greetings.js`: new module with `greet()` function — pure, no side effects, no dependencies
- `src/greetings.test.js`: automated tests covering all 6 PATs using `node:test` and `node:assert`

## PAT Results
- [x] PAT-1: `greet("Bob", "casual")` → `"Hey Bob!"` — passed
- [x] PAT-2: `greet("Alice", "formal")` → `"Good day, Alice. It is a pleasure."` — passed
- [x] PAT-3: `greet("Charlie", "pirate")` → `"Ahoy, Charlie! Shiver me timbers!"` — passed
- [x] PAT-4: `greet("Dave")` → `"Hey Dave!"` (undefined default) — passed
- [x] PAT-5: `greet("Dave", null)` → `"Hey Dave!"` (null default) — passed
- [x] PAT-6: `greet("Eve", "unknown")` throws `Error("Unknown mode: unknown")` — passed

## Test Coverage
- [x] All existing tests pass
- [x] Automated tests written for all PATs
- [x] No regressions

## Notes for Reviewer
Package uses ESM (`"type": "module"`), so module uses `export function` syntax. Tests use `node:test` with `describe`/`it` as specified in constraints.