### PR TITLE
feat: implement greeting mode functions (#2)

### DIFF
--- a/src/greetings.js
+++ b/src/greetings.js
@@ -1,0 +1,20 @@
+/**
+ * Returns a greeting string for the given name and mode.
+ * @param {string} name
+ * @param {'formal'|'casual'|'pirate'|null|undefined} mode
+ * @returns {string}
+ */
+export function greet(name, mode) {
+  const resolved = mode == null ? 'casual' : mode;
+
+  switch (resolved) {
+    case 'formal':
+      return `Good day, ${name}. It is a pleasure.`;
+    case 'casual':
+      return `Hey ${name}!`;
+    case 'pirate':
+      return `Ahoy, ${name}! Shiver me timbers!`;
+    default:
+      throw new Error(`Unknown mode: ${resolved}`);
+  }
+}

--- a/src/greetings.test.js
+++ b/src/greetings.test.js
@@ -1,0 +1,36 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { greet } from './greetings.js';
+
+// PAT-1: Casual greeting
+test('greet returns casual greeting', () => {
+  assert.equal(greet('Bob', 'casual'), 'Hey Bob!');
+});
+
+// PAT-2: Formal greeting
+test('greet returns formal greeting', () => {
+  assert.equal(greet('Alice', 'formal'), 'Good day, Alice. It is a pleasure.');
+});
+
+// PAT-3: Pirate greeting
+test('greet returns pirate greeting', () => {
+  assert.equal(greet('Charlie', 'pirate'), 'Ahoy, Charlie! Shiver me timbers!');
+});
+
+// PAT-4: Default mode (undefined)
+test('greet defaults to casual when mode is undefined', () => {
+  assert.equal(greet('Dave'), 'Hey Dave!');
+});
+
+// PAT-5: Default mode (null)
+test('greet defaults to casual when mode is null', () => {
+  assert.equal(greet('Dave', null), 'Hey Dave!');
+});
+
+// PAT-6: Unknown mode throws
+test('greet throws for unknown mode', () => {
+  assert.throws(
+    () => greet('Eve', 'unknown'),
+    { message: 'Unknown mode: unknown' }
+  );
+});


### PR DESCRIPTION
## Summary
Closes #2

Implements `src/greetings.js` exporting a `greet(name, mode)` function supporting formal, casual, and pirate greeting modes. Includes automated tests covering all 6 PATs.

## Changes
- `src/greetings.js`: exports `greet(name, mode)` — pure function, no side effects, ESM
- `src/greetings.test.js`: 6 tests using `node:test` and `node:assert`, one per PAT

## PAT Results
- [x] PAT-1: `greet("Bob", "casual")` → `"Hey Bob!"` — passed
- [x] PAT-2: `greet("Alice", "formal")` → `"Good day, Alice. It is a pleasure."` — passed
- [x] PAT-3: `greet("Charlie", "pirate")` → `"Ahoy, Charlie! Shiver me timbers!"` — passed
- [x] PAT-4: `greet("Dave")` → `"Hey Dave!"` (undefined default) — passed
- [x] PAT-5: `greet("Dave", null)` → `"Hey Dave!"` (null default) — passed
- [x] PAT-6: `greet("Eve", "unknown")` throws `Error("Unknown mode: unknown")` — passed

## Test Coverage
- [x] All existing tests pass
- [x] Automated tests written for all PATs
- [x] No regressions

## Notes for Reviewer
No external dependencies used. ESM exports (`export function greet`) required because `package.json` sets `"type": "module"`.