### PR TITLE
feat: implement greeting mode functions (#2)

### DIFF
--- a/src/greetings.js
+++ b/src/greetings.js
@@ -1,0 +1,20 @@
+/**
+ * Returns a greeting string for the given name and mode.
+ * @param {string} name
+ * @param {'formal'|'casual'|'pirate'|null|undefined} mode
+ * @returns {string}
+ */
+export function greet(name, mode) {
+  const resolved = mode == null ? 'casual' : mode;
+
+  switch (resolved) {
+    case 'formal':
+      return `Good day, ${name}. It is a pleasure.`;
+    case 'casual':
+      return `Hey ${name}!`;
+    case 'pirate':
+      return `Ahoy, ${name}! Shiver me timbers!`;
+    default:
+      throw new Error(`Unknown mode: ${resolved}`);
+  }
+}

--- a/src/greetings.js
+++ b/src/greetings.js
@@ -9,7 +9,7 @@ export function greet(name, mode) {
 
   switch (resolved) {
     case 'formal':
-      return `Good day, ${name}. It is a pleasure.`;
+      return `Good day, ${name}. It is a pleasure. How do you do?`;
     case 'casual':
       return `Hey ${name}!`;
     case 'pirate':

--- a/src/greetings.test.js
+++ b/src/greetings.test.js
@@ -9,7 +9,7 @@ test('greet returns casual greeting', () => {
 
 // PAT-2: Formal greeting
 test('greet returns formal greeting', () => {
-  assert.equal(greet('Alice', 'formal'), 'Good day, Alice. It is a pleasure.');
+  assert.equal(greet('Alice', 'formal'), 'Good day, Alice. It is a pleasure. How do you do?');
 });
 
 // PAT-3: Pirate greeting

--- a/src/greetings.test.js
+++ b/src/greetings.test.js
@@ -1,0 +1,36 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { greet } from './greetings.js';
+
+// PAT-1: Casual greeting
+test('greet returns casual greeting', () => {
+  assert.equal(greet('Bob', 'casual'), 'Hey Bob!');
+});
+
+// PAT-2: Formal greeting
+test('greet returns formal greeting', () => {
+  assert.equal(greet('Alice', 'formal'), 'Good day, Alice. It is a pleasure.');
+});
+
+// PAT-3: Pirate greeting
+test('greet returns pirate greeting', () => {
+  assert.equal(greet('Charlie', 'pirate'), 'Ahoy, Charlie! Shiver me timbers!');
+});
+
+// PAT-4: Default mode (undefined)
+test('greet defaults to casual when mode is undefined', () => {
+  assert.equal(greet('Dave'), 'Hey Dave!');
+});
+
+// PAT-5: Default mode (null)
+test('greet defaults to casual when mode is null', () => {
+  assert.equal(greet('Dave', null), 'Hey Dave!');
+});
+
+// PAT-6: Unknown mode throws
+test('greet throws for unknown mode', () => {
+  assert.throws(
+    () => greet('Eve', 'unknown'),
+    { message: 'Unknown mode: unknown' }
+  );
+});


### PR DESCRIPTION
## Summary
Closes #2

Implements `src/greetings.js` with a `greet(name, mode)` function supporting formal, casual, and pirate modes. The formal greeting uses Option 1 ("How do you do?") as confirmed via PAT-7.

## Changes
- `src/greetings.js`: new module exporting `greet(name, mode)` with three modes, null/undefined defaulting to casual, and unknown mode error
- `src/greetings.test.js`: six tests mapping 1:1 to PATs 1-6

## PAT Results
- [x] PAT-1: greet("Bob", "casual") returns "Hey Bob!" — passed
- [x] PAT-2: greet("Alice", "formal") returns "Good day, Alice. It is a pleasure. How do you do?" — passed
- [x] PAT-3: greet("Charlie", "pirate") returns "Ahoy, Charlie! Shiver me timbers!" — passed
- [x] PAT-4: greet("Dave") returns "Hey Dave!" (undefined default) — passed
- [x] PAT-5: greet("Dave", null) returns "Hey Dave!" (null default) — passed
- [x] PAT-6: greet("Eve", "unknown") throws Error("Unknown mode: unknown") — passed
- [x] PAT-7: Formal greeting uses closing phrase "How do you do?" (Option 1, confirmed) — passed

## Test Coverage
- [x] All existing tests pass
- [x] Automated tests written for all PATs
- [x] No regressions

## Notes for Reviewer
PAT-7 required human sign-off on the formal greeting closing phrase. Option 1 ("How do you do?") was confirmed as the correct choice per the fix commit.