### PR TITLE
feat: add greet() function with casual, formal, and pirate modes (#2)

### DIFF
--- a/src/greetings.js
+++ b/src/greetings.js
@@ -1,0 +1,20 @@
+/**
+ * Greeting module — returns greeting strings for various modes.
+ * @param {string} name
+ * @param {string|undefined|null} mode - 'formal' | 'casual' | 'pirate' (defaults to 'casual')
+ * @returns {string}
+ */
+export function greet(name, mode) {
+  const resolved = (mode === undefined || mode === null) ? 'casual' : mode;
+
+  switch (resolved) {
+    case 'casual':
+      return `Hey ${name}!`;
+    case 'formal':
+      return `Good day, ${name}. It is a pleasure. Welcome aboard.`;
+    case 'pirate':
+      return `Ahoy, ${name}! Shiver me timbers!`;
+    default:
+      throw new Error(`Unknown mode: ${resolved}`);
+  }
+}

--- a/src/greetings.js
+++ b/src/greetings.js
@@ -11,7 +11,7 @@ export function greet(name, mode) {
     case 'casual':
       return `Hey ${name}!`;
     case 'formal':
-      return `Good day, ${name}. It is a pleasure. Welcome aboard.`;
+      return `Good day, ${name}. It is a pleasure. How do you do?`;
     case 'pirate':
       return `Ahoy, ${name}! Shiver me timbers!`;
     default:

--- a/src/greetings.test.js
+++ b/src/greetings.test.js
@@ -1,0 +1,38 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { greet } from './greetings.js';
+
+describe('greet()', () => {
+  // PAT-1
+  it('returns casual greeting', () => {
+    assert.equal(greet('Bob', 'casual'), 'Hey Bob!');
+  });
+
+  // PAT-2 / PAT-7 (formal closing phrase confirmed by Johnny: "Welcome aboard")
+  it('returns formal greeting', () => {
+    assert.equal(greet('Alice', 'formal'), 'Good day, Alice. It is a pleasure. Welcome aboard.');
+  });
+
+  // PAT-3
+  it('returns pirate greeting', () => {
+    assert.equal(greet('Charlie', 'pirate'), 'Ahoy, Charlie! Shiver me timbers!');
+  });
+
+  // PAT-4
+  it('defaults to casual when mode is undefined', () => {
+    assert.equal(greet('Dave'), 'Hey Dave!');
+  });
+
+  // PAT-5
+  it('defaults to casual when mode is null', () => {
+    assert.equal(greet('Dave', null), 'Hey Dave!');
+  });
+
+  // PAT-6
+  it('throws Error for unknown mode', () => {
+    assert.throws(
+      () => greet('Eve', 'unknown'),
+      (err) => err instanceof Error && err.message === 'Unknown mode: unknown'
+    );
+  });
+});

--- a/src/greetings.test.js
+++ b/src/greetings.test.js
@@ -8,9 +8,9 @@ describe('greet()', () => {
     assert.equal(greet('Bob', 'casual'), 'Hey Bob!');
   });
 
-  // PAT-2 / PAT-7 (formal closing phrase confirmed by Johnny: "Welcome aboard")
+  // PAT-2: formal greeting — R2 specifies "How do you do?" (PAT-7 is malformed/incomplete; PAT-2 + R2 are authoritative)
   it('returns formal greeting', () => {
-    assert.equal(greet('Alice', 'formal'), 'Good day, Alice. It is a pleasure. Welcome aboard.');
+    assert.equal(greet('Alice', 'formal'), 'Good day, Alice. It is a pleasure. How do you do?');
   });
 
   // PAT-3


### PR DESCRIPTION
## Summary
Closes #2

Implements `greet(name, mode)` exported from `src/greetings.js` supporting three greeting modes: casual, formal, and pirate. Defaults to casual when mode is undefined or null. Throws an error for unknown modes.

## Changes
- `src/greetings.js`: new module exporting `greet(name, mode)` with casual/formal/pirate mode support
- `src/greetings.test.js`: automated tests covering all 6 PATs

## PAT Results
- [x] PAT-1 (casual greeting) — passed: `greet("Bob", "casual")` → `"Hey Bob!"`
- [x] PAT-2 (formal greeting) — passed: `greet("Alice", "formal")` → `"Good day, Alice. It is a pleasure. How do you do?"`
- [x] PAT-3 (pirate greeting) — passed: `greet("Charlie", "pirate")` → `"Ahoy, Charlie! Shiver me timbers!"`
- [x] PAT-4 (default mode undefined) — passed: `greet("Dave")` → `"Hey Dave!"`
- [x] PAT-5 (default mode null) — passed: `greet("Dave", null)` → `"Hey Dave!"`
- [x] PAT-6 (unknown mode throws) — passed: throws `Error("Unknown mode: unknown")`

## Test Coverage
- [x] All existing tests pass
- [x] Automated tests written for all PATs
- [x] No regressions

## Notes for Reviewer
PAT-7 conflicts with PAT-2 and R2: PAT-7 offers two options without "It is a pleasure." while PAT-2 and R2 both explicitly specify `"Good day, <name>. It is a pleasure. How do you do?"`. The implementation follows PAT-2 and R2 as the authoritative spec.