### PR TITLE
feat: implement greeting mode functions (#2)

### DIFF
--- a/src/greetings.js
+++ b/src/greetings.js
@@ -1,0 +1,20 @@
+/**
+ * Returns a greeting string for the given name and mode.
+ * @param {string} name
+ * @param {'formal'|'casual'|'pirate'|null|undefined} mode - defaults to 'casual'
+ * @returns {string}
+ */
+export function greet(name, mode) {
+  const resolvedMode = (mode == null) ? 'casual' : mode;
+
+  switch (resolvedMode) {
+    case 'casual':
+      return `Hey ${name}!`;
+    case 'formal':
+      return `Good day, ${name}. It is a pleasure. How do you do?`;
+    case 'pirate':
+      return `Ahoy, ${name}! Shiver me timbers!`;
+    default:
+      throw new Error(`Unknown mode: ${resolvedMode}`);
+  }
+}

--- a/src/greetings.test.js
+++ b/src/greetings.test.js
@@ -1,0 +1,42 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { greet } from './greetings.js';
+
+describe('greet()', () => {
+  // PAT-1
+  it('returns casual greeting', () => {
+    assert.equal(greet('Bob', 'casual'), 'Hey Bob!');
+  });
+
+  // PAT-2, PAT-7
+  it('returns formal greeting', () => {
+    assert.equal(greet('Alice', 'formal'), 'Good day, Alice. It is a pleasure. How do you do?');
+  });
+
+  // PAT-3
+  it('returns pirate greeting', () => {
+    assert.equal(greet('Charlie', 'pirate'), 'Ahoy, Charlie! Shiver me timbers!');
+  });
+
+  // PAT-4
+  it('defaults to casual when mode is undefined', () => {
+    assert.equal(greet('Dave'), 'Hey Dave!');
+  });
+
+  // PAT-5
+  it('defaults to casual when mode is null', () => {
+    assert.equal(greet('Dave', null), 'Hey Dave!');
+  });
+
+  // PAT-6
+  it('throws Error with correct message for unknown mode', () => {
+    assert.throws(
+      () => greet('Eve', 'unknown'),
+      (err) => {
+        assert(err instanceof Error);
+        assert.equal(err.message, 'Unknown mode: unknown');
+        return true;
+      }
+    );
+  });
+});


### PR DESCRIPTION
## Summary
Closes #2

Implements `greet(name, mode)` in `src/greetings.js` supporting three greeting modes: casual, formal, and pirate. Defaults to casual when mode is undefined or null; throws an Error for unknown modes.

## Changes
- `src/greetings.js`: New module exporting `greet(name, mode)` with all three modes
- `src/greetings.test.js`: 6 automated tests covering all PATs (node:test + node:assert)

## PAT Results
- [x] PAT-1: `greet("Bob", "casual")` → `"Hey Bob!"` — passed
- [x] PAT-2: `greet("Alice", "formal")` → `"Good day, Alice. It is a pleasure. How do you do?"` — passed
- [x] PAT-3: `greet("Charlie", "pirate")` → `"Ahoy, Charlie! Shiver me timbers!"` — passed
- [x] PAT-4: `greet("Dave")` → `"Hey Dave!"` (undefined → casual) — passed
- [x] PAT-5: `greet("Dave", null)` → `"Hey Dave!"` (null → casual) — passed
- [x] PAT-6: `greet("Eve", "unknown")` throws `Error("Unknown mode: unknown")` — passed
- [x] PAT-7: Formal greeting format confirmed — passed

## Test Coverage
- [x] All existing tests pass
- [x] Automated tests written for all PATs
- [x] No regressions

## Notes for Reviewer
Uses ES module syntax (`export function`) to match the project's `"type": "module"` setting in package.json.