### PR TITLE
👷 add CI workflow for agent test harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install deps (skip if lockfile absent)
+        run: |
+          if [ -f package-lock.json ]; then npm ci; else npm install; fi
+
+      - name: Syntax check
+        run: |
+          for f in $(find src -name '*.js' 2>/dev/null); do
+            node --check "$f"
+          done
+
+      - name: Run tests
+        run: npm test


### PR DESCRIPTION
Prereq for Outpost Phase B test sprint. Enables the CI gate (Phase 1.5 in sm-orchestrator.sh) to have actual checks to gate on. Without this, CI scenarios silently fall-through as "no CI configured."