### PR TITLE
feat: add trim(str) utility (#29)

### DIFF
--- a/src/trim.js
+++ b/src/trim.js
@@ -1,0 +1,3 @@
+export default function trim(str) {
+  return str.replace(/^\s+|\s+$/g, '');
+}

--- a/src/trim.test.js
+++ b/src/trim.test.js
@@ -1,0 +1,23 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import trim from './trim.js';
+
+test("trim('  hello  ') returns 'hello'", () => {
+  assert.equal(trim('  hello  '), 'hello');
+});
+
+test("trim('hello') returns 'hello'", () => {
+  assert.equal(trim('hello'), 'hello');
+});
+
+test("trim('\\t\\nhello\\n\\t') returns 'hello'", () => {
+  assert.equal(trim('\t\nhello\n\t'), 'hello');
+});
+
+test("trim('   ') returns ''", () => {
+  assert.equal(trim('   '), '');
+});
+
+test("trim('') returns ''", () => {
+  assert.equal(trim(''), '');
+});


### PR DESCRIPTION
## Summary
Closes #29

Implements a pure `trim(str)` function in `src/trim.js` that removes leading and trailing whitespace (spaces, tabs, newlines) without using `String.prototype.trim`. Uses a regex-based approach (`/^\s+|\s+$/g`) as explicitly permitted by the spec.

## Changes
- `src/trim.js`: new `trim(str)` function, regex-based, exported as default ESM export
- `src/trim.test.js`: 5 tests covering all PATs using `node:test`

## PAT Results
- [x] `trim('  hello  ')` returns `'hello'` — passed
- [x] `trim('hello')` returns `'hello'` — passed
- [x] `trim('\t\nhello\n\t')` returns `'hello'` — passed
- [x] `trim('   ')` returns `''` — passed
- [x] `trim('')` returns `''` — passed

## Test Coverage
- [x] All existing tests pass
- [x] Automated tests written for all PATs
- [x] No regressions

## Notes for Reviewer
Implementation uses `String.prototype.replace` with a regex pattern rather than `String.prototype.trim` — this is the "regex" approach explicitly listed in the spec. The `\s` character class covers spaces, tabs, and newlines as required.