### PR TITLE
feat: add normalizeEmail(email) utility (#31)

### DIFF
--- a/src/normalizeEmail.js
+++ b/src/normalizeEmail.js
@@ -1,0 +1,13 @@
+export default function normalizeEmail(email) {
+  if (email === '') throw new Error('Input required');
+
+  const trimmed = email.trim();
+
+  const atIndex = trimmed.indexOf('@');
+  if (atIndex === -1) throw new Error('Invalid email');
+
+  const local = trimmed.slice(0, atIndex).toLowerCase().replace(/\+.*$/, '').replace(/\.{2,}/g, '.');
+  const domain = trimmed.slice(atIndex + 1).toLowerCase();
+
+  return `${local}@${domain}`;
+}

--- a/src/normalizeEmail.test.js
+++ b/src/normalizeEmail.test.js
@@ -1,0 +1,31 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import normalizeEmail from './normalizeEmail.js';
+
+test("normalizeEmail('User@Example.COM') returns 'user@example.com'", () => {
+  assert.equal(normalizeEmail('User@Example.COM'), 'user@example.com');
+});
+
+test("normalizeEmail('  alice@example.com  ') returns 'alice@example.com'", () => {
+  assert.equal(normalizeEmail('  alice@example.com  '), 'alice@example.com');
+});
+
+test("normalizeEmail('bob+promo@example.com') returns 'bob@example.com'", () => {
+  assert.equal(normalizeEmail('bob+promo@example.com'), 'bob@example.com');
+});
+
+test("normalizeEmail('bob+a+b+c@example.com') returns 'bob@example.com' (first plus only)", () => {
+  assert.equal(normalizeEmail('bob+a+b+c@example.com'), 'bob@example.com');
+});
+
+test("normalizeEmail('a..b@example.com') returns 'a.b@example.com'", () => {
+  assert.equal(normalizeEmail('a..b@example.com'), 'a.b@example.com');
+});
+
+test("normalizeEmail('bad-no-at') throws Error 'Invalid email'", () => {
+  assert.throws(() => normalizeEmail('bad-no-at'), { message: 'Invalid email' });
+});
+
+test("normalizeEmail('') throws Error 'Input required'", () => {
+  assert.throws(() => normalizeEmail(''), { message: 'Input required' });
+});


### PR DESCRIPTION
## Summary
Closes #31

Implements `normalizeEmail(email)` in `src/normalizeEmail.js` — a pure function that returns the canonical form of an email address. All five normalisation rules are applied in sequence: trim whitespace, lowercase both parts, strip plus-aliasing from local part, and collapse consecutive dots in local part. Invalid or empty inputs throw appropriate errors.

## Changes
- `src/normalizeEmail.js`: new utility implementing all 5 normalisation rules with error handling
- `src/normalizeEmail.test.js`: 7 tests covering all PATs

## PAT Results
- [x] `normalizeEmail('User@Example.COM')` → `'user@example.com'` — passed
- [x] `normalizeEmail('  alice@example.com  ')` → `'alice@example.com'` — passed
- [x] `normalizeEmail('bob+promo@example.com')` → `'bob@example.com'` — passed
- [x] `normalizeEmail('bob+a+b+c@example.com')` → `'bob@example.com'` — passed
- [x] `normalizeEmail('a..b@example.com')` → `'a.b@example.com'` — passed
- [x] `normalizeEmail('bad-no-at')` throws Error `'Invalid email'` — passed
- [x] `normalizeEmail('')` throws Error `'Input required'` — passed

## Test Coverage
- [x] All existing tests pass
- [x] Automated tests written for all PATs
- [x] No regressions

## Notes for Reviewer
Plus-aliasing strips everything from the first `+` to the `@`, consistent with PAT-4's clarification that `bob+a+b+c` becomes `bob` (before the FIRST `+`).