### PR TITLE
feat: add toUpper(str) ASCII-only uppercase utility (#37)

### DIFF
--- a/src/toUpper.js
+++ b/src/toUpper.js
@@ -1,0 +1,3 @@
+export default function toUpper(str) {
+  return str.replace(/[a-z]/g, c => c.toUpperCase());
+}

--- a/src/toUpper.test.js
+++ b/src/toUpper.test.js
@@ -1,0 +1,21 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import toUpper from './toUpper.js';
+
+describe('toUpper', () => {
+  it('uppercases all lowercase letters', () => {
+    assert.equal(toUpper('hello'), 'HELLO');
+  });
+
+  it('uppercases mixed case with punctuation', () => {
+    assert.equal(toUpper('Hello, World!'), 'HELLO, WORLD!');
+  });
+
+  it('uppercases letters and leaves digits unchanged', () => {
+    assert.equal(toUpper('abc123'), 'ABC123');
+  });
+
+  it('returns empty string unchanged', () => {
+    assert.equal(toUpper(''), '');
+  });
+});


### PR DESCRIPTION
## Summary
Closes #37

Implements a pure `toUpper(str)` function in `src/toUpper.js` that uppercases ASCII letters (a-z) only, leaving non-ASCII characters, digits, and punctuation unchanged. Exported as default ESM.

## Changes
- `src/toUpper.js`: implements `toUpper` using a regex replace on `[a-z]` characters only
- `src/toUpper.test.js`: 4 tests covering all PATs using node:test

## PAT Results
- [x] `toUpper('hello')` → `'HELLO'` — passed
- [x] `toUpper('Hello, World!')` → `'HELLO, WORLD!'` — passed
- [x] `toUpper('abc123')` → `'ABC123'` — passed
- [x] `toUpper('')` → `''` — passed

## Test Coverage
- [x] All existing tests pass
- [x] Automated tests written for all PATs
- [x] No regressions

## Notes for Reviewer
Unicode characters (é, ñ, ß) are explicitly out of scope per the issue spec. The `[a-z]` regex ensures only ASCII lowercase letters are matched — `.toUpperCase()` on `String.prototype.replace` handles the conversion cleanly.