### PR TITLE
feat: add greet(name, opts) with --upper option (#39)

### DIFF
--- a/src/greet.js
+++ b/src/greet.js
@@ -1,0 +1,5 @@
+export default function greet(name, opts = {}) {
+  if (!name) throw new Error('Name required');
+  const greeting = `Hello, ${name}!`;
+  return opts.upper ? greeting.toUpperCase() : greeting;
+}

--- a/src/greet.test.js
+++ b/src/greet.test.js
@@ -1,0 +1,25 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import greet from './greet.js';
+
+describe('greet', () => {
+  it("greet('Alice') returns 'Hello, Alice!'", () => {
+    assert.equal(greet('Alice'), 'Hello, Alice!');
+  });
+
+  it("greet('Alice', { upper: true }) returns 'HELLO, ALICE!'", () => {
+    assert.equal(greet('Alice', { upper: true }), 'HELLO, ALICE!');
+  });
+
+  it("greet('alice', { upper: true }) returns 'HELLO, ALICE!' (input case doesn't matter)", () => {
+    assert.equal(greet('alice', { upper: true }), 'HELLO, ALICE!');
+  });
+
+  it("greet('') throws Error 'Name required'", () => {
+    assert.throws(() => greet(''), { message: 'Name required' });
+  });
+
+  it("greet('', { upper: true }) throws Error 'Name required' (option doesn't bypass validation)", () => {
+    assert.throws(() => greet('', { upper: true }), { message: 'Name required' });
+  });
+});


### PR DESCRIPTION
## Summary
Closes #39

Adds `src/greet.js` exporting a `greet(name, opts)` function. With no options it returns `'Hello, <name>!'`; with `{ upper: true }` it returns the greeting fully uppercased. Empty name throws `Error('Name required')` regardless of options.

## Changes
- `src/greet.js`: new module — `export default greet(name, opts = {})` with validation and uppercase support
- `src/greet.test.js`: five tests covering all five PATs

## PAT Results
- [x] `greet('Alice')` → `'Hello, Alice!'` — passed
- [x] `greet('Alice', { upper: true })` → `'HELLO, ALICE!'` — passed
- [x] `greet('alice', { upper: true })` → `'HELLO, ALICE!'` — passed
- [x] `greet('')` throws `Error('Name required')` — passed
- [x] `greet('', { upper: true })` throws `Error('Name required')` — passed

## Test Coverage
- [x] All existing tests pass
- [x] Automated tests written for all PATs
- [x] No regressions

## Notes for Reviewer
`toUpper.js` from PR #37 is not yet on main, so uppercase is implemented via native `.toUpperCase()`. Both are behaviourally equivalent for the ASCII characters tested in the PATs.