### PR TITLE
feat: extract greet(name) from src/index.js with CLI wrapper (#45)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,10 @@
 #!/usr/bin/env node
 
-// Greeting CLI — entry point
-// Usage: node src/index.js [name]
+export function greet(name) {
+  const resolved = name || 'World';
+  return `Hello, ${resolved}!`;
+}
 
-const name = process.argv[2] || 'World';
-console.log(`Hello, ${name}!`);
+if (import.meta.url === `file://${process.argv[1]}`) {
+  console.log(greet(process.argv[2]));
+}

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,6 +1,11 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
 import { greet } from './index.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 describe('greet', () => {
   it("greet('Alice') returns 'Hello, Alice!'", () => {
@@ -13,5 +18,13 @@ describe('greet', () => {
 
   it("greet('') returns 'Hello, World!'", () => {
     assert.equal(greet(''), 'Hello, World!');
+  });
+});
+
+describe('CLI', () => {
+  it('running with no args prints Hello, World!', () => {
+    const result = spawnSync(process.execPath, [join(__dirname, 'index.js')], { encoding: 'utf8' });
+    assert.equal(result.stdout, 'Hello, World!\n');
+    assert.equal(result.status, 0);
   });
 });

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,0 +1,17 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { greet } from './index.js';
+
+describe('greet', () => {
+  it("greet('Alice') returns 'Hello, Alice!'", () => {
+    assert.equal(greet('Alice'), 'Hello, Alice!');
+  });
+
+  it("greet(undefined) returns 'Hello, World!'", () => {
+    assert.equal(greet(undefined), 'Hello, World!');
+  });
+
+  it("greet('') returns 'Hello, World!'", () => {
+    assert.equal(greet(''), 'Hello, World!');
+  });
+});


### PR DESCRIPTION
## Summary
Closes #45

Refactors `src/index.js` to export a `greet(name)` function and use it from a thin CLI entry-point wrapper. Behaviour is identical to before: no-arg or empty-string input resolves to `'Hello, World!'`.

## Changes
- `src/index.js`: exported `greet(name)` function with `import.meta.url` CLI guard; shebang retained
- `src/index.test.js`: new test file codifying all four PATs

## PAT Results
- [x] `greet('Alice')` returns `'Hello, Alice!'` — passed
- [x] `greet(undefined)` returns `'Hello, World!'` — passed
- [x] `greet('')` returns `'Hello, World!'` — passed
- [x] CLI with no args prints `Hello, World!` — passed

## Test Coverage
- [x] All existing tests pass
- [x] Automated tests written for all PATs
- [x] No regressions

## Notes for Reviewer
No new dependencies added. The `import.meta.url` guard ensures the CLI output only fires when the file is run directly, not when imported as a module.