### PR TITLE
✨ upgrade outpost.yml to schema v1

### DIFF
--- a/outpost.yml
+++ b/outpost.yml
@@ -1,6 +1,16 @@
+version: 1
+name: hello-agentic-test
+
 runtimes:
   - node:22
 
 services: []
 
 mcp: []
+
+agents:
+  models:
+    dev: sonnet
+    qa:  sonnet
+    rev: opus
+  max_iterations: 2


### PR DESCRIPTION
Lockstep with [outpost#50](https://github.com/textologylabs/outpost/pull/50). Outpost now requires `version: 1` and `name` on `outpost.yml`, and adds the `agents:` block. This PR upgrades to the new shape:

- Adds required `version: 1` and `name` fields.
- Adds `agents.models` — explicit per-role model selection: Opus on rev (judgment role), Sonnet on dev/qa (cost-effective coders).
- Adds `agents.max_iterations: 2` — replaces the old global `/op config rejection-budget` knob with a per-project setting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)