### PR TITLE
🔧 bump outpost.yml to version 2

### DIFF
--- a/outpost.yml
+++ b/outpost.yml
@@ -1,4 +1,4 @@
-version: 1
+version: 2
 name: hello-agentic-test
 
 runtimes:


### PR DESCRIPTION
## Summary

- Flip `version: 1` → `version: 2` to satisfy the slice 2 schema cut in [textologylabs/outpost#63](https://github.com/textologylabs/outpost/pull/63).
- v2 is shape-identical to v1 except for the new optional `m:` block, so no other changes needed.

## Why

Slice 2 of #70 (Outpost) removes the v1 path. Once that lands and deploys to the VPS, any `outpost.yml` still on `version: 1` will be rejected at `add-project` and SM start time. This is the source-repo bump the slice 2 design called out as a deploy prerequisite.

## Test plan

- [ ] Merge.
- [ ] Outpost slice 2 deploys to VPS without v1 rejection.
- [ ] `add-project hello-agentic-test` registers cleanly post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)